### PR TITLE
workflow: run every 6 hour

### DIFF
--- a/.github/workflows/repomd.yml
+++ b/.github/workflows/repomd.yml
@@ -2,6 +2,8 @@ name: repomd
 on:
   - push
   - workflow_dispatch
+  schedule:
+    - cron:  '01 * * * *'
 
 jobs:
   repomd:

--- a/.github/workflows/repomd.yml
+++ b/.github/workflows/repomd.yml
@@ -3,7 +3,7 @@ on:
   - push
   - workflow_dispatch
   schedule:
-    - cron:  '01 * * * *'
+    - cron:  '0 0,6,12,18 * * *'
 
 jobs:
   repomd:


### PR DESCRIPTION
Quickly grab new package updates.

The metadata needs to be updated every time a package publish a new release.
Rebuilding it every hour, seems a good compromise.

