### PR TITLE
Fix case of app names

### DIFF
--- a/mariadb/metadata.json
+++ b/mariadb/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "mariadb",
+  "name": "MariaDB",
   "source": "ghcr.io/nethserver/mariadb",
   "description": {
     "en": "MariaDB Server is a SQL database, with its user interface PhpMyadmin"

--- a/minio/metadata.json
+++ b/minio/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "minio",
+  "name": "MinIO",
   "description": {
     "en": "MinIO: S3 compatible object storage"
   },


### PR DESCRIPTION
If app names use different cases (eg. "Dokuwiki" vs "mariadb") then apps are not sorted correctly in **Software center** page