### PR TITLE
dokuwiki: fix case in name

### DIFF
--- a/dokuwiki/metadata.json
+++ b/dokuwiki/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "Dokuwiki",
+  "name": "DokuWiki",
   "source": "ghcr.io/nethserver/dokuwiki",
   "description": {
     "en": "Wiki that doesn't require a database"


### PR DESCRIPTION
Correct name is DokuWiki