### PR TITLE
Add `RC2` to NethVoice and NethVoice-Proxy modules

### DIFF
--- a/nethvoice-proxy/metadata.json
+++ b/nethvoice-proxy/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "NethVoice Proxy",
+  "name": "NethVoice Proxy RC2",
   "description": {
     "en": "NethVoice proxy module"
   },

--- a/nethvoice/metadata.json
+++ b/nethvoice/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "NethVoice",
+  "name": "NethVoice RC2",
   "description": {
     "en": "NethVoice Module",
     "it": "Modulo NethVoice"


### PR DESCRIPTION
The module version will be set to a non-prerelease version, but the module has not yet reached the stable phase in the development cycle.