### PR TITLE
Update code URLs in metadata for ldapproxy, loki, and traefik

### DIFF
--- a/ldapproxy/metadata.json
+++ b/ldapproxy/metadata.json
@@ -13,7 +13,7 @@
   "docs": {
     "documentation_url": "https://nethserver.github.io/ns8-core",
     "bug_url": "https://github.com/NethServer/dev",
-    "code_url": "https://github.com/NethServer/ns8-core"
+    "code_url": "https://github.com/NethServer/ns8-ldapproxy"
   },
   "source": "ghcr.io/nethserver/ldapproxy"
 }

--- a/loki/metadata.json
+++ b/loki/metadata.json
@@ -13,7 +13,7 @@
   "docs": {
     "documentation_url": "https://nethserver.github.io/ns8-core",
     "bug_url": "https://github.com/NethServer/dev",
-    "code_url": "https://github.com/NethServer/ns8-core"
+    "code_url": "https://github.com/NethServer/ns8-loki"
   },
   "source": "ghcr.io/nethserver/loki"
 }

--- a/traefik/metadata.json
+++ b/traefik/metadata.json
@@ -13,7 +13,7 @@
   "docs": {
     "documentation_url": "https://nethserver.github.io/ns8-core",
     "bug_url": "https://github.com/NethServer/dev",
-    "code_url": "https://github.com/NethServer/ns8-core"
+    "code_url": "https://github.com/NethServer/ns8-traefik"
   },
   "source": "ghcr.io/nethserver/traefik"
 }


### PR DESCRIPTION
Correct the code URLs in the metadata files for ldapproxy, loki, and traefik to point to their respective repositories.

https://github.com/NethServer/dev/issues/7243