### PR TITLE
Update url of documentation

### DIFF
--- a/nethvoice/metadata.json
+++ b/nethvoice/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://github.com/nethesis/ns8-nethvoice",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/nethvoice.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/nethesis/ns8-nethvoice"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `nethvoice/metadata.json` file to point to the latest official documentation for NethVoice.

* [`nethvoice/metadata.json`](diffhunk://#diff-55c65f6c5915afcdb158a56b9d00106cd2826f2aea4c0e9dc109ee24f8ddbb28L15-R15): Updated the `documentation_url` to `https://docs.nethserver.org/projects/ns8/en/latest/nethvoice.html` to provide a more accurate and up-to-date reference for NethVoice documentation.

https://github.com/NethServer/dev/issues/7399