### PR TITLE
Update url of documentation

### DIFF
--- a/nethvoice-proxy/metadata.json
+++ b/nethvoice-proxy/metadata.json
@@ -11,7 +11,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://github.com/nethesis/ns8-nethvoice-proxy",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/nethvoice_proxy.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/nethesis/ns8-nethvoice-proxy"
 },


### PR DESCRIPTION
This pull request updates the documentation URL in the `nethvoice-proxy/metadata.json` file to point to the official NethServer documentation site.

* [`nethvoice-proxy/metadata.json`](diffhunk://#diff-42971201b9435237fe5f71edf2e475db9f862827fca0ee199184317426e63856L14-R14): Updated the `documentation_url` field to use the new URL `https://docs.nethserver.org/projects/ns8/en/latest/nethvoice_proxy.html` for improved accuracy and consistency with the official documentation.

https://github.com/NethServer/dev/issues/7399