### PR TITLE
Update url of documentation

### DIFF
--- a/core/metadata.json
+++ b/core/metadata.json
@@ -11,7 +11,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/index.html#",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-core"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `core/metadata.json` file to point to the latest version of the NethServer NS8 documentation.

* [`core/metadata.json`](diffhunk://#diff-cea53c6e74e238235fdfd9c7484126f9543620b7d9919e3e3e1311c476204b29L14-R14): Updated the `documentation_url` field to `https://docs.nethserver.org/projects/ns8/en/latest/index.html#` to reflect the new location of the documentation.

https://github.com/NethServer/dev/issues/7399