### PR TITLE
Update url of documentation

### DIFF
--- a/loki/metadata.json
+++ b/loki/metadata.json
@@ -11,7 +11,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://nethserver.github.io/ns8-core",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/log_server.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-loki"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `loki/metadata.json` file to point to a more specific and up-to-date page.

* [`loki/metadata.json`](diffhunk://#diff-bb054b0e0f6437a35e012a92d2483141d94af0b3735837f8ca6a61855af8d7dbL14-R14): Changed the `documentation_url` from a general core documentation link to a specific page about the log server in the NethServer NS8 documentation.

https://github.com/NethServer/dev/issues/7399