### PR TITLE
Update url of documentation

### DIFF
--- a/traefik/metadata.json
+++ b/traefik/metadata.json
@@ -11,7 +11,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://nethserver.github.io/ns8-core",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/proxy.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-traefik"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `traefik/metadata.json` file to point to a more specific and updated location.

* Updated the `documentation_url` in `traefik/metadata.json` to `https://docs.nethserver.org/projects/ns8/en/latest/proxy.html` for more accurate and detailed documentation.

https://github.com/NethServer/dev/issues/7399