### PR TITLE
Update url of documentation

### DIFF
--- a/openldap/metadata.json
+++ b/openldap/metadata.json
@@ -11,7 +11,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://nethserver.github.io/ns8-core",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/user_domains.html#ldap-server-rfc2307",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-openldap"
   },


### PR DESCRIPTION
This pull request updates the `documentation_url` in the `openldap/metadata.json` file to point to a more specific and relevant section of the documentation.

* [`openldap/metadata.json`](diffhunk://#diff-af08ceec98d881e9ba627f534fd4b7cda09faf4011f0c833141f56c4c80a335aL14-R14): Updated the `documentation_url` to link directly to the LDAP Server RFC2307 section in the NethServer NS8 documentation for improved clarity and user guidance.

https://github.com/NethServer/dev/issues/7399