### PR TITLE
Pin tag 1.6.1 for NC33 upgrade

### DIFF
--- a/pins.yml
+++ b/pins.yml
@@ -15,6 +15,7 @@ nextcloud:
   - { tag: 1.3.0, prepend: False } # from NC28 to NC29 #7347
   - { tag: 1.4.3, prepend: False } # from NC29 to NC30
   - { tag: 1.5.2, prepend: False } # from NC30 to NC31 #7728
+  - { tag: 1.6.1, prepend: False } # from NC31 to NC32 #7928
 mattermost:
   - { tag: 2.1.1, prepend: False } # MM 9.11 to 10.5 #7245
   - { tag: 2.2.0, prepend: False } # PG 13 to 17 #7628


### PR DESCRIPTION
Nextcloud doesn't allow upgrades over 2 major versions

NethServer/dev#7928