### PR TITLE
Remove tag 1.7.0 for NC33 upgrade

### DIFF
--- a/pins.yml
+++ b/pins.yml
@@ -17,6 +17,7 @@ nextcloud:
   - { tag: 1.5.2, prepend: False } # from NC30 to NC31 #7728
   - { tag: 1.6.1, prepend: False } # from NC31 to NC32 #7928
   - { match: "1.7.0", remove: True } # NC33 withdrawal
+  - { tag: 1.7.1, prepend: False } # from NC32 to NC33 #7986
 mattermost:
   - { tag: 2.1.1, prepend: False } # MM 9.11 to 10.5 #7245
   - { tag: 2.2.0, prepend: False } # PG 13 to 17 #7628

--- a/pins.yml
+++ b/pins.yml
@@ -16,7 +16,6 @@ nextcloud:
   - { tag: 1.4.3, prepend: False } # from NC29 to NC30
   - { tag: 1.5.2, prepend: False } # from NC30 to NC31 #7728
   - { tag: 1.6.1, prepend: False } # from NC31 to NC32 #7928
-  - { match: "1.7.0", remove: True } # NC33 withdrawal
   - { tag: 1.7.1, prepend: False } # from NC32 to NC33 #7986
 mattermost:
   - { tag: 2.1.1, prepend: False } # MM 9.11 to 10.5 #7245

--- a/pins.yml
+++ b/pins.yml
@@ -16,7 +16,6 @@ nextcloud:
   - { tag: 1.4.3, prepend: False } # from NC29 to NC30
   - { tag: 1.5.2, prepend: False } # from NC30 to NC31 #7728
   - { tag: 1.6.1, prepend: False } # from NC31 to NC32 #7928
-  - { tag: 1.7.1, prepend: False } # from NC32 to NC33 #7986
 mattermost:
   - { tag: 2.1.1, prepend: False } # MM 9.11 to 10.5 #7245
   - { tag: 2.2.0, prepend: False } # PG 13 to 17 #7628


### PR DESCRIPTION
This pull request makes a small change to the `pins.yml` file for the `nextcloud` service. The entry for version `1.7.0` has been removed, which previously indicated a withdrawal for NC33.

* Removed the `{ match: "1.7.0", remove: True }` entry from the `nextcloud` section, reflecting the end of the NC33 withdrawal..


https://github.com/NethServer/dev/issues/7986